### PR TITLE
Add support for Filament v4 and v5 alongside v3

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,17 +18,27 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*]
+        filament: [5.*, 4.*, 3.*]
         stability: [prefer-lowest, prefer-stable]
+        # Each Filament major is paired with a different Laravel major, so that one run of the
+        # matrix covers every supported Filament version and every supported Laravel version.
+        # `--with` (see below) intersects these with the constraint in composer.json, so
+        # `prefer-lowest` still respects the declared `^3.3` lower bound for Filament v3.
         include:
-          - laravel: 12.*
+          - filament: 5.*
+            laravel: 13.*
+            testbench: 11.*
+            carbon: ^3
+          - filament: 4.*
+            laravel: 12.*
             testbench: 10.*
             carbon: ^3
-          - laravel: 11.*
+          - filament: 3.*
+            laravel: 11.*
             testbench: 9.*
             carbon: ^2.63
 
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
+    name: P${{ matrix.php }} - F${{ matrix.filament }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
@@ -49,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.os == 'windows-latest' && '^^^' || '' }}${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --with="filament/filament:${{ matrix.filament }}" --prefer-dist --no-interaction
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@
 
 A Filament field for the redactor WYSIWYG editor.
 
+## Compatibility
+
+A single version of this package supports Filament v3, v4 and v5 — there is no separate branch or major version per Filament release.
+
+| Requirement | Supported versions |
+|-------------|--------------------|
+| PHP         | 8.3, 8.4           |
+| Laravel     | 11, 12, 13         |
+| Filament    | v3.3, v4, v5       |
+
+Composer resolves a working combination for you. Note that Filament decides which Laravel versions each of its own majors supports — Filament v4 and v5 require Laravel 11.28 or newer, for example.
+
 ## Installation
 ```bash
 # Install the package using composer

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
     ],
     "require": {
         "php": "^8.3",
-        "filament/filament": "^3.3",
-        "illuminate/contracts": "^12.0||^11.0",
+        "filament/filament": "^3.3||^4.0||^5.0",
+        "illuminate/contracts": "^13.0||^12.0||^11.0",
         "spatie/laravel-package-tools": "^1.16"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0",
-        "orchestra/testbench": "^10.0.0||^9.0.0",
-        "pestphp/pest": "^3.0",
-        "pestphp/pest-plugin-arch": "^3.0",
-        "pestphp/pest-plugin-laravel": "^3.0"
+        "orchestra/testbench": "^11.0.0||^10.0.0||^9.0.0",
+        "pestphp/pest": "^4.0||^3.0",
+        "pestphp/pest-plugin-arch": "^4.0||^3.0",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/config/filament-redactor-field.php
+++ b/config/filament-redactor-field.php
@@ -1,25 +1,27 @@
 <?php
 
+use TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin;
+
 // config for TimoDeWinter/FilamentRedactorField
 return [
     'darkmode_enabled' => true,
 
     'plugins' => [
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::Alignment,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::BlockBackground,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::BlockBorder,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::BlockColor,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::BlockFontsize,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::BlockSpacing,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::Emoji,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::FontColor,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::FontFamily,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::FontSize,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::FullScreen,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::Icons,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::ImageResize,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::Limiter,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::SpecialChars,
-        \TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin::TextExpander,
+        DefaultRedactorPlugin::Alignment,
+        DefaultRedactorPlugin::BlockBackground,
+        DefaultRedactorPlugin::BlockBorder,
+        DefaultRedactorPlugin::BlockColor,
+        DefaultRedactorPlugin::BlockFontsize,
+        DefaultRedactorPlugin::BlockSpacing,
+        DefaultRedactorPlugin::Emoji,
+        DefaultRedactorPlugin::FontColor,
+        DefaultRedactorPlugin::FontFamily,
+        DefaultRedactorPlugin::FontSize,
+        DefaultRedactorPlugin::FullScreen,
+        DefaultRedactorPlugin::Icons,
+        DefaultRedactorPlugin::ImageResize,
+        DefaultRedactorPlugin::Limiter,
+        DefaultRedactorPlugin::SpecialChars,
+        DefaultRedactorPlugin::TextExpander,
     ],
 ];

--- a/resources/views/fields/redactor-editor.blade.php
+++ b/resources/views/fields/redactor-editor.blade.php
@@ -14,7 +14,7 @@
                 updateUsing: (newState) => {
                     state = newState;
                 },
-                withDarkMode: @js($getWithDarkMode),
+                withDarkMode: @js($getWithDarkMode()),
                 plugins: @js($getPlugins()),
                 @if(!is_null($maxLength = $getMaxLength()))
                     limiter: {

--- a/src/Fields/RedactorEditor.php
+++ b/src/Fields/RedactorEditor.php
@@ -31,7 +31,7 @@ class RedactorEditor extends Field
             ->toArray();
     }
 
-    public function plugins(array $plugins): static
+    public function plugins(array|Closure $plugins): static
     {
         $this->plugins = $plugins;
 

--- a/tests/Fixtures/RedactorEditorTestComponent.php
+++ b/tests/Fixtures/RedactorEditorTestComponent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace TimoDeWinter\FilamentRedactorField\Tests\Fixtures;
+
+use Closure;
+use Filament\Forms\Concerns\InteractsWithForms;
+use Filament\Forms\Contracts\HasForms;
+use Illuminate\Contracts\View\View;
+use Livewire\Component;
+use TimoDeWinter\FilamentRedactorField\Fields\RedactorEditor;
+
+/**
+ * The form is configured through `getFormSchema()` / `getFormStatePath()` rather than by
+ * overriding `form()`, because the `form()` signature differs between Filament versions
+ * (`Filament\Forms\Form` on v3, `Filament\Schemas\Schema` on v4 and v5).
+ */
+class RedactorEditorTestComponent extends Component implements HasForms
+{
+    use InteractsWithForms;
+
+    /** @var array<string, mixed> */
+    public array $data = [];
+
+    /** @var Closure(RedactorEditor): RedactorEditor|null */
+    public static ?Closure $configureUsing = null;
+
+    public function mount(): void
+    {
+        $this->getForm('form')->fill();
+    }
+
+    public function render(): View
+    {
+        return view('filament-redactor-field-tests::form');
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    protected function getFormSchema(): array
+    {
+        $field = RedactorEditor::make('content');
+
+        if (static::$configureUsing instanceof Closure) {
+            $field = (static::$configureUsing)($field);
+        }
+
+        return [$field];
+    }
+
+    protected function getFormStatePath(): ?string
+    {
+        return 'data';
+    }
+}

--- a/tests/Fixtures/views/form.blade.php
+++ b/tests/Fixtures/views/form.blade.php
@@ -1,0 +1,3 @@
+<div>
+    {{ $this->getForm('form') }}
+</div>

--- a/tests/RedactorEditorTest.php
+++ b/tests/RedactorEditorTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use Livewire\Livewire;
+use TimoDeWinter\FilamentRedactorField\Enums\DefaultRedactorPlugin;
+use TimoDeWinter\FilamentRedactorField\Fields\RedactorEditor;
+use TimoDeWinter\FilamentRedactorField\Tests\Fixtures\RedactorEditorTestComponent;
+
+afterEach(function () {
+    RedactorEditorTestComponent::$configureUsing = null;
+});
+
+it('renders the alpine component inside a field wrapper', function () {
+    Livewire::test(RedactorEditorTestComponent::class)
+        ->assertOk()
+        ->assertSee('redactorEditor(', escape: false)
+        ->assertSee('x-load-js', escape: false)
+        ->assertSee('redactor-plugin.js', escape: false)
+        ->assertSee('data.content', escape: false)
+        ->assertSee('withDarkMode: true', escape: false);
+});
+
+it('passes the configured plugins to the editor', function () {
+    RedactorEditorTestComponent::$configureUsing = fn (RedactorEditor $field) => $field
+        ->plugins([DefaultRedactorPlugin::Alignment, 'counter']);
+
+    Livewire::test(RedactorEditorTestComponent::class)
+        ->assertSee('alignment', escape: false)
+        ->assertSee('counter', escape: false);
+});
+
+it('renders a limiter when a max length is set', function () {
+    RedactorEditorTestComponent::$configureUsing = fn (RedactorEditor $field) => $field
+        ->maxLength(600);
+
+    Livewire::test(RedactorEditorTestComponent::class)
+        ->assertSee('limit: 600', escape: false);
+});
+
+it('disables the limiter when no max length is set', function () {
+    Livewire::test(RedactorEditorTestComponent::class)
+        ->assertSee('limiter: false', escape: false);
+});
+
+it('renders an upload endpoint when one is set', function () {
+    RedactorEditorTestComponent::$configureUsing = fn (RedactorEditor $field) => $field
+        ->uploadEndpoint('/redactor/upload');
+
+    // `@js()` escapes the forward slashes of the endpoint.
+    Livewire::test(RedactorEditorTestComponent::class)
+        ->assertSee('upload: \'\/redactor\/upload\'', escape: false);
+});
+
+it('resolves its options through closures', function () {
+    $field = RedactorEditor::make('content')
+        ->plugins(fn () => ['counter'])
+        ->withDarkMode(fn () => false)
+        ->maxLength(fn () => 120)
+        ->uploadEndpoint(fn () => '/upload');
+
+    expect($field->getPlugins())->toBe(['counter'])
+        ->and($field->getWithDarkMode())->toBeFalse()
+        ->and($field->getMaxLength())->toBe(120)
+        ->and($field->getUploadEndpoint())->toBe('/upload');
+});
+
+it('falls back to the config for plugins and dark mode', function () {
+    config()->set('filament-redactor-field.plugins', [DefaultRedactorPlugin::Emoji]);
+    config()->set('filament-redactor-field.darkmode_enabled', false);
+
+    $field = RedactorEditor::make('content');
+
+    expect($field->getPlugins())->toBe(['emoji'])
+        ->and($field->getWithDarkMode())->toBeFalse();
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,11 +3,20 @@
 namespace TimoDeWinter\FilamentRedactorField\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\View;
 use Orchestra\Testbench\TestCase as Orchestra;
 use TimoDeWinter\FilamentRedactorField\FilamentRedactorFieldServiceProvider;
 
 class TestCase extends Orchestra
 {
+    /**
+     * Let Testbench discover the Filament and Livewire service providers, so the test suite
+     * does not have to hard-code a provider list that differs per Filament major version.
+     *
+     * @var bool
+     */
+    protected $enablesPackageDiscoveries = true;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -15,6 +24,8 @@ class TestCase extends Orchestra
         Factory::guessFactoryNamesUsing(
             fn (string $modelName) => 'TimoDeWinter\\FilamentRedactorField\\Database\\Factories\\'.class_basename($modelName).'Factory'
         );
+
+        View::addNamespace('filament-redactor-field-tests', __DIR__.'/Fixtures/views');
     }
 
     protected function getPackageProviders($app)
@@ -27,6 +38,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        config()->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
 
         /*
          foreach (\Illuminate\Support\Facades\File::allFiles(__DIR__ . '/database/migrations') as $migration) {


### PR DESCRIPTION
## Summary

This package previously supported only Filament v3 on Laravel 11/12. It now supports Filament v3.3, v4 and v5 from a single version — no separate branch or major release per Filament version — plus Laravel 13. Along the way this fixes two bugs found while making the field version-agnostic, and adds a real test suite that renders the field through Livewire.

The CI matrix pairs each Filament major with a different Laravel major so one matrix run covers every supported combination of both, and uses `composer update --with` so `prefer-lowest` still honours the lower bounds declared in `composer.json`.

## Notable changes

- **`composer.json`**: widen `filament/filament` to `^3.3||^4.0||^5.0`, `illuminate/contracts` to `^13.0||^12.0||^11.0`, `orchestra/testbench` to include `^11.0`, and allow Pest v4 alongside v3.
- **CI**: replace the `laravel` matrix axis with a `filament` axis (`5.*`, `4.*`, `3.*`), each `include`d with its paired Laravel/Testbench/Carbon versions; job names now show the Filament version, and the Filament constraint is applied via `composer update --with`.
- **Bug fix — dark mode**: `withDarkMode: @js($getWithDarkMode)` in the Blade view passed the closure itself instead of calling it; now `@js($getWithDarkMode())`.
- **Bug fix — `plugins()`**: accepts `array|Closure` so plugins can be resolved lazily like the field's other options.
- **Tests**: new `RedactorEditorTest` covering Alpine component rendering, plugin configuration, the max-length limiter, the upload endpoint, closure resolution of all options, and config fallbacks.
- **Test harness**: new `RedactorEditorTestComponent` fixture that configures its form via `getFormSchema()`/`getFormStatePath()` rather than overriding `form()`, whose signature differs across Filament majors (`Forms\Form` on v3 vs `Schemas\Schema` on v4/v5), with a matching `form.blade.php` fixture view.
- **`TestCase`**: enable package discovery so Filament/Livewire providers are resolved per Filament major instead of being hard-coded, register the fixture view namespace, and set an `app.key` for the test environment.
- **README**: document the supported PHP, Laravel and Filament versions, and note that Filament itself governs which Laravel versions each of its majors supports.